### PR TITLE
Allocating 20 history elements simultaneously

### DIFF
--- a/include/history.h
+++ b/include/history.h
@@ -1,6 +1,9 @@
 #ifndef _HISTORY_H
 #define _HISTORY_H
 
+
+#define HISTORY_RECORDS_BEFORE_REALLOC 20
+
 struct history {
     int size;
     char **records;

--- a/src/history.c
+++ b/src/history.c
@@ -28,18 +28,20 @@ void clear_history() {
 
 void add_to_history(struct history* h, char* in) {
 
-    // Void pointer for temporarily storing h->record's realloc
-    void *hrealloc;
+    if (h->size % HISTORY_RECORDS_BEFORE_REALLOC == 0) {
+        // Void pointer for temporarily storing h->record's realloc
+        void *hrealloc;
 
-    if ((hrealloc = realloc(h->records, (h->size + 1) * sizeof(char *)))) {
-        // Contine if realloc succeded
-        h->records = hrealloc;
-    }
-    else {
-        // Exit
-        endwin();
-        fprintf(stderr, "OUT OF MEMORY");
-        exit(-1);
+        if ((hrealloc = realloc(h->records, (h->size + 1) * sizeof(char *) * HISTORY_RECORDS_BEFORE_REALLOC))) {
+            // Contine if realloc succeded
+            h->records = hrealloc;
+        }
+        else {
+            // Exit
+            endwin();
+            fprintf(stderr, "OUT OF MEMORY");
+            exit(-1);
+        }
     }
 
     if ((h->records[h->size++] = strdup(*in == '\0' && h == &history ? "0" : in)) == NULL) {


### PR DESCRIPTION
Hello,

as mentioned in the last pull request. The reallo should only happen on every 20th `add_to_history()`.
I included this in the current setting but this can be changed by the `HISTORY_RECORDS_BEFORE_REALLOC` defined in the `history.h` file.

DevManu-de