### PR TITLE
Use the getopt function to parse commandline options

### DIFF
--- a/include/operators.h
+++ b/include/operators.h
@@ -4,6 +4,13 @@
 #define DEFAULT_MASK -1
 #define DEFAULT_MASK_SIZE 64
 
+/* Supress unused parameter warnings */
+#ifdef __GNUC__
+#   define UNUSED(x) UNUSED_##x __attribute__((__unused__))
+#else
+#   define UNUSED(x) UNUSED_##x
+#endif
+
 // Operations Control
 // Example: '+' takes two operands, therefore the noperands = 2
 typedef struct operation {

--- a/src/main.c
+++ b/src/main.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <limits.h>
 #include <ncurses.h>
+#include <unistd.h>
 
 #include "draw.h"
 #include "global.h"
@@ -65,45 +66,39 @@ extern operation operations[];
 
 int main(int argc, char *argv[])
 {
-
     // Get command line options to hide parts of the display
-    if (argc >= 2 && argv[1][0] == '-') {
+    int opt;
+    while ((opt = getopt(argc, argv, "hbxdos")) != -1) {
+        switch (opt) {
+        case 'h':
+            history_enabled = 0;
+            break;
 
-        for (int i=1; argv[1][i] != '\0'; i++) {
+        case 'b':
+            binary_enabled = 0;
+            break;
 
-            switch (argv[1][i]) {
+        case 'x':
+            hex_enabled = 0;
+            break;
 
-                case 'h':
-                    history_enabled = 0;
-                    break;
+        case 'd':
+            decimal_enabled = 0;
+            break;
 
-                case 'b':
-                    binary_enabled = 0;
-                    break;
+        case 'o':
+            operation_enabled = 0;
+            break;
 
-                case 'x':
-                    hex_enabled = 0;
-                    break;
+        case 's':
+            symbols_enabled = 0;
+            break;
 
-                case 'd':
-                    decimal_enabled = 0;
-                    break;
-
-                case 'o':
-                    operation_enabled = 0;
-                    break;
-
-                case 's':
-                    symbols_enabled = 0;
-                    break;
-		default:
-		    fprintf(stderr, "Unrecognized option: -%c\n", argv[1][i]);
-		    exit(EXIT_FAILURE);
-
-            }
-
+        default:
+            exit(EXIT_FAILURE);
         }
     }
+
 
     init_gui(&displaywin, &inputwin);
 

--- a/src/main.c
+++ b/src/main.c
@@ -377,6 +377,11 @@ void get_input(char *in) {
             if (i <= MAX_IN) {
                 // Append char to in array
                 in[i++] = inp;
+
+                /* Avoid having to enter % twice */
+                if (inp == '%')
+                    in[i++] = inp;
+
                 in[i] = '\0';
                 if (inp == '\0')
                 {

--- a/src/operators.c
+++ b/src/operators.c
@@ -148,12 +148,12 @@ long long modulus(long long a, long long b) {
     return (b % a) & globalmask;
 }
 
-long long not(long long a, long long b) {
+long long not(long long a, long long UNUSED(b)) {
 
     return ~a & globalmask;
 }
 
-long long twos_complement(long long a, long long b) {
+long long twos_complement(long long a, long long UNUSED(b)) {
 
     return (~a + 1) & globalmask;
 }


### PR DESCRIPTION
This allows you to pass command line options in both the following forms:
```
$ pcalc -bx
$ pcalc -b -x
```