### PR TITLE
Fixing #31 first 2 problems

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -387,10 +387,6 @@ void get_input(char *in) {
                 // Append char to in array
                 in[i++] = inp;
 
-                /* Avoid having to enter % twice */
-                if (inp == '%')
-                    in[i++] = inp;
-
                 in[i] = '\0';
                 if (inp == '\0')
                 {
@@ -402,7 +398,7 @@ void get_input(char *in) {
         // Finaly print input
         sweepline(inputwin, 1, 22);
 
-        mvwprintw(inputwin, 1, 22, in);
+        mvwprintw(inputwin, 1, 22, "%s", in);
         wrefresh(inputwin);
     }
 


### PR DESCRIPTION
This pr solves follwing 2 bugs from #31 

> I have been testing with the % sign and found out that entering % requires to press backspace twice.
> In addition to that I found out that entering `%` and pressing `backspace` one and then enter `G` causes pcalc to output `4.64142e-10` other combinations of `%` `backspace` and `other keys` cause output like `(NULL)` or even freeze pcalc.

> I have listed some combination that I have found out.

> % + backsapce + G = `4.64142e-310`
> % + backspace + S = `(NULL)`
> % + backspace + C = pcalc freezes (CTRL-C exits, Enter crashes)
> % + backspace + D = `0`


IMPORTANT: This does NOT fix:
> As if this is not enough I found out that entering %d or any other printf like format pcalc crashes immediately with the response Floating point exception (core dumped)

Maybe someone else could test it again.

DevManu-de