### PR TITLE
Prevent input overflow

### DIFF
--- a/include/global.h
+++ b/include/global.h
@@ -2,6 +2,7 @@
 #define _GLOBAL_H
 
 #define MAX_IN 80
+#define INPUT_START 24
 
 #define MEM_FAIL -1
 

--- a/src/main.c
+++ b/src/main.c
@@ -441,6 +441,10 @@ static void get_input(char* in) {
 
     // Collect input until enter is pressed
     for (int pos = 0, len = 0; (inp = getchar()) != 13;) {
+
+        // Get max possible input length
+        int max = getmaxx(inputwin) - 24;
+
         int searched = 0;
         
         // Handles all arrow keys
@@ -498,7 +502,7 @@ static void get_input(char* in) {
         }
 
         // Prevent user to input more than MAX_IN
-        if(!searched && len <= MAX_IN) {
+        if(!searched && len <= max && len <= MAX_IN) {
             if (!browsing) {
                 // If the cursor is at the end of the text
                 

--- a/src/main.c
+++ b/src/main.c
@@ -148,7 +148,7 @@ int main(int argc, char* argv[])
     for (;;) {
 
         // Get input
-        char in[MAX_IN+1];
+        char in[MAX_IN + 1];
 
         // Make sure that if enter is pressed, a len == 0 null terminated string is in "in"
         in[0] = '\0';
@@ -443,7 +443,7 @@ static void get_input(char* in) {
     for (int pos = 0, len = 0; (inp = getchar()) != 13;) {
 
         // Get max possible input length
-        int max = getmaxx(inputwin) - 24;
+        int max = getmaxx(inputwin) - INPUT_START;
 
         int searched = 0;
         


### PR DESCRIPTION
This prevents the user to input more than the screen width and `MAX_IN`

I think this is a much cleaner approach than @kippenjongen.