### PR TITLE
Added previously removed sweepline

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -498,6 +498,9 @@ static void get_input(char* in) {
         // This saves having to increment pos everytime len is incremented when youre not browsing
         if (!browsing) { pos = len; }
 
+        // Clear input (only necessary because of the history feature)
+        sweepline(inputwin, 1, 22);
+
         // Finaly print input
         mvwprintw(inputwin, 1, 22, "%s", in);
 


### PR DESCRIPTION
@alt-romes 
This is the sweepline I suggested to remove in #56 but it is necessary but only for the history feature which i didnt check because it wasnt never mentioned that it is only for the history.

I added the comment to make it clear and fixed it.
Sorry!

DevManu-de