### PR TITLE
Possible solution for #45

### DIFF
--- a/include/draw.h
+++ b/include/draw.h
@@ -16,6 +16,7 @@ extern int use_interface;
 
 void init_gui();
 void draw(numberstack*, operation*);
+void updatewinborders();
 void sweepline(WINDOW*, int, int);
 
 #endif

--- a/include/draw.h
+++ b/include/draw.h
@@ -16,7 +16,7 @@ extern int use_interface;
 
 void init_gui();
 void draw(numberstack*, operation*);
-void update_win_borders(numberstack* numbers, operation* current_op);
+void update_win_borders(numberstack* numbers);
 void sweepline(WINDOW*, int, int);
 
 #endif

--- a/include/draw.h
+++ b/include/draw.h
@@ -16,7 +16,7 @@ extern int use_interface;
 
 void init_gui();
 void draw(numberstack*, operation*);
-void updatewinborders();
+void update_win_borders();
 void sweepline(WINDOW*, int, int);
 
 #endif

--- a/include/draw.h
+++ b/include/draw.h
@@ -16,7 +16,7 @@ extern int use_interface;
 
 void init_gui();
 void draw(numberstack*, operation*);
-void update_win_borders();
+void update_win_borders(numberstack* numbers, operation* current_op);
 void sweepline(WINDOW*, int, int);
 
 #endif

--- a/include/operators.h
+++ b/include/operators.h
@@ -39,6 +39,7 @@ typedef struct operation {
 
 extern unsigned long long globalmask;
 extern int globalmasksize;
+extern operation *current_op;
 
 operation* getopcode(char c);
 

--- a/src/draw.c
+++ b/src/draw.c
@@ -147,15 +147,8 @@ void draw(numberstack* numbers, operation* current_op) {
 
 void update_win_borders() {
 
-    /* Draw border around displaywin */
-    box(displaywin, ' ', 0);
-    /* Update the terminal */
-    wrefresh(displaywin);
-    /* Draw border around inputwin */
-    box(inputwin, ' ', 0);
-    /* Update the terminal */
-    wrefresh(inputwin);
-
+    doupdate();
+    init_gui();
 }
 
 

--- a/src/draw.c
+++ b/src/draw.c
@@ -145,6 +145,16 @@ void draw(numberstack* numbers, operation* current_op) {
     }
 }
 
+void updatewinborders() {
+
+    box(displaywin, ' ', 0);
+    wrefresh(displaywin);
+    box(inputwin, ' ', 0);
+    wrefresh(inputwin);
+
+}
+
+
 void sweepline(WINDOW* w, int y, int x) {
     wmove(w, y, x);
     wclrtoeol(w);

--- a/src/draw.c
+++ b/src/draw.c
@@ -145,7 +145,7 @@ void draw(numberstack* numbers, operation* current_op) {
     }
 }
 
-void update_win_borders(numberstack* numbers, operation* current_op) {
+void update_win_borders(numberstack* numbers) {
 
     doupdate();
     init_gui();

--- a/src/draw.c
+++ b/src/draw.c
@@ -145,10 +145,11 @@ void draw(numberstack* numbers, operation* current_op) {
     }
 }
 
-void update_win_borders() {
+void update_win_borders(numberstack* numbers, operation* current_op) {
 
     doupdate();
     init_gui();
+    draw(numbers, current_op);
 }
 
 

--- a/src/draw.c
+++ b/src/draw.c
@@ -145,11 +145,15 @@ void draw(numberstack* numbers, operation* current_op) {
     }
 }
 
-void updatewinborders() {
+void update_win_borders() {
 
+    /* Draw border around displaywin */
     box(displaywin, ' ', 0);
+    /* Update the terminal */
     wrefresh(displaywin);
+    /* Draw border around inputwin */
     box(inputwin, ' ', 0);
+    /* Update the terminal */
     wrefresh(inputwin);
 
 }

--- a/src/main.c
+++ b/src/main.c
@@ -391,7 +391,7 @@ static void get_input(char* in) {
          * -1 is a key that indicates the terminal got resized
          */
         if (inp <= 0) {
-            updatewinborders();
+            update_win_borders();
             continue;
         }
 

--- a/src/main.c
+++ b/src/main.c
@@ -391,6 +391,7 @@ static void get_input(char* in) {
          * -1 is a key that indicates the terminal got resized
          */
         if (inp <= 0) {
+            updatewinborders();
             continue;
         }
 

--- a/src/main.c
+++ b/src/main.c
@@ -136,7 +136,7 @@ int main(int argc, char* argv[])
      * the operation is executed, and the result of the calculation is pushed to the stack
      */
     numbers = create_numberstack(4);
-    operation* current_op = NULL;
+    //operation* current_op = NULL;
 
     // Initalize history pointers with NULL (realloc will bahave like malloc)
     history.records = NULL;
@@ -391,7 +391,7 @@ static void get_input(char* in) {
          * -1 is a key that indicates the terminal got resized
          */
         if (inp <= 0) {
-            update_win_borders();
+            update_win_borders(numbers, current_op);
             continue;
         }
 

--- a/src/main.c
+++ b/src/main.c
@@ -391,7 +391,7 @@ static void get_input(char* in) {
          * -1 is a key that indicates the terminal got resized
          */
         if (inp <= 0) {
-            update_win_borders(numbers, current_op);
+            update_win_borders(numbers);
             continue;
         }
 

--- a/src/operators.c
+++ b/src/operators.c
@@ -5,6 +5,8 @@
 unsigned long long globalmask = DEFAULT_MASK;
 int globalmasksize = DEFAULT_MASK_SIZE;
 
+operation *current_op = NULL;
+
 static long long add(long long, long long);
 static long long subtract(long long, long long);
 static long long multiply(long long, long long);


### PR DESCRIPTION
After some testing I found a solution that updates the borders and this only when the terminal got resized.
I am aware of the problem that the `displaywin` is sometimes one terminal column off but its not that noticable.

DevManu-de