### PR TITLE
Fixed memory leak when allocation fails #77

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ pcalc
 .DS_Store
 .gitignore
 .vscode/*.json
+compile_flags.txt

--- a/include/xmalloc.h
+++ b/include/xmalloc.h
@@ -3,9 +3,15 @@
 
 #include <stdlib.h>
 
+#include "global.h"
+
 void *xmalloc(size_t bytes);
+void *xmalloc_with_ressources(size_t bytes, void** ressources, size_t nres);
 void *xcalloc(size_t nelem, size_t bytes);
+void *xcalloc_with_ressources(size_t nelem, size_t bytes, void** ressources, size_t nres);
 void *xrealloc(void *pntr, size_t bytes);
+void *xrealloc_with_ressources(void *pntr, size_t bytes, void** ressources, size_t nres);
+void xfreen(void** pntrs, size_t npntrs);
 void xfree(void *pntr);
 
 #endif

--- a/include/xmalloc.h
+++ b/include/xmalloc.h
@@ -5,13 +5,13 @@
 
 #include "global.h"
 
-void *xmalloc(size_t bytes);
-void *xmalloc_with_ressources(size_t bytes, void** ressources, size_t nres);
-void *xcalloc(size_t nelem, size_t bytes);
-void *xcalloc_with_ressources(size_t nelem, size_t bytes, void** ressources, size_t nres);
-void *xrealloc(void *pntr, size_t bytes);
-void *xrealloc_with_ressources(void *pntr, size_t bytes, void** ressources, size_t nres);
+void* xmalloc(size_t bytes);
+void* xmalloc_with_ressources(size_t bytes, void** ressources, size_t nres);
+void* xcalloc(size_t nelem, size_t bytes);
+void* xcalloc_with_ressources(size_t nelem, size_t bytes, void** ressources, size_t nres);
+void* xrealloc(void* pntr, size_t bytes);
+void* xrealloc_with_ressources(void* pntr, size_t bytes, void** ressources, size_t nres);
 void xfreen(void** pntrs, size_t npntrs);
-void xfree(void *pntr);
+void xfree(void* pntr);
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -44,17 +44,17 @@ int main(int argc, char* argv[])
     // Set all long arguments that can be used
     struct option long_options[] = {
 
-        {"help", no_argument, NULL, 'h'},
-        {"version", no_argument, NULL, 'v'},
-        {"history", no_argument, NULL, 'i'},
-        {"binary", no_argument, NULL, 'b'},
-        {"hex", no_argument, NULL, 'x'},
-        {"decimal", no_argument, NULL, 'd'},
-        {"operation", no_argument, NULL, 'o'},
-        {"symbol", no_argument, NULL, 's'},
-        {"colors", no_argument, NULL, 'c'},
-	{"no-interface", no_argument, NULL, 'n'},
-	{0,0,0,0}
+        {"help",            no_argument, NULL, 'h'},
+        {"version",         no_argument, NULL, 'v'},
+        {"history",         no_argument, NULL, 'i'},
+        {"binary",          no_argument, NULL, 'b'},
+        {"hex",             no_argument, NULL, 'x'},
+        {"decimal",         no_argument, NULL, 'd'},
+        {"operation",       no_argument, NULL, 'o'},
+        {"symbol",          no_argument, NULL, 's'},
+        {"colors",          no_argument, NULL, 'c'},
+        {"no-interface",    no_argument, NULL, 'n'},
+        {NULL,              0,           NULL,  0}
 
      };
 

--- a/src/numberstack.c
+++ b/src/numberstack.c
@@ -13,7 +13,8 @@ numberstack * create_numberstack(int max_size) {
 
     numberstack* s;
     s = xmalloc(sizeof(numberstack));
-    s->elements = xmalloc(max_size * sizeof(long long));
+    void *allocated[] = { s };
+    s->elements = xmalloc_with_ressources(max_size * sizeof(*s->elements), allocated, 1);
     s->size = 0;
     s->max_size = max_size;
     return s;
@@ -22,7 +23,8 @@ numberstack * create_numberstack(int max_size) {
 static numberstack * resize_numberstack(numberstack* s) {
 
     s->max_size *= 2;
-    s->elements = xrealloc(s->elements, s->max_size * sizeof(long long));
+    void* allocated[] = { s };
+    s->elements = xrealloc_with_ressources(s->elements, s->max_size * sizeof(*s->elements), allocated, 1);
     return s;
 
 }

--- a/src/numberstack.c
+++ b/src/numberstack.c
@@ -13,7 +13,7 @@ numberstack * create_numberstack(int max_size) {
 
     numberstack* s;
     s = xmalloc(sizeof(numberstack));
-    void *allocated[] = { s };
+    void* allocated[] = { s };
     s->elements = xmalloc_with_ressources(max_size * sizeof(*s->elements), allocated, 1);
     s->size = 0;
     s->max_size = max_size;

--- a/src/parser.c
+++ b/src/parser.c
@@ -424,7 +424,8 @@ static exprtree create_exprtree(int type, void* content, exprtree left, exprtree
 
     else {
 
-        expr->value = xmalloc(sizeof(long long));
+        void* allocated[] = { expr };
+        expr->value = xmalloc_with_ressources(sizeof(*expr->value), allocated, 1);
         *(expr->value) = *((long long*) content);
     }
 

--- a/src/xmalloc.c
+++ b/src/xmalloc.c
@@ -7,7 +7,7 @@ void *xmalloc(size_t bytes) {
     return xmalloc_with_ressources(bytes, NULL, 0);
 }
 
-void *xmalloc_with_ressources(size_t bytes, void** ressources, size_t nres) {
+void* xmalloc_with_ressources(size_t bytes, void** ressources, size_t nres) {
     void* temp = malloc(bytes);
     if (temp == NULL) {
         xfreen(ressources, nres);
@@ -16,12 +16,12 @@ void *xmalloc_with_ressources(size_t bytes, void** ressources, size_t nres) {
     return temp;
 }
 
-void *xcalloc(size_t nelem, size_t bytes) {
+void* xcalloc(size_t nelem, size_t bytes) {
 
     return xcalloc_with_ressources(nelem, bytes, NULL, 0);
 }
 
-void *xcalloc_with_ressources(size_t nelem, size_t bytes, void** ressources, size_t nres) {
+void* xcalloc_with_ressources(size_t nelem, size_t bytes, void** ressources, size_t nres) {
     void *temp = calloc(nelem, bytes);
     if (temp == NULL) {
         xfreen(ressources, nres);
@@ -30,14 +30,14 @@ void *xcalloc_with_ressources(size_t nelem, size_t bytes, void** ressources, siz
     return temp;
 }
 
-void *xrealloc(void *pntr, size_t bytes) {
+void* xrealloc(void *pntr, size_t bytes) {
 
     return xrealloc_with_ressources(pntr, bytes, NULL, 0);
 }
 
-void *xrealloc_with_ressources(void *pntr, size_t bytes, void** ressources, size_t nres) {
+void* xrealloc_with_ressources(void* pntr, size_t bytes, void** ressources, size_t nres) {
 
-    void *temp = pntr ? realloc(pntr, bytes) : xmalloc(bytes);
+    void* temp = pntr ? realloc(pntr, bytes) : xmalloc(bytes);
     if (temp == NULL) {
         xfreen(ressources, nres);
         exit_pcalc(MEM_FAIL);
@@ -51,6 +51,6 @@ void xfreen(void** pntrs, size_t npntrs) {
     }
 }
 
-void xfree(void *pntr) {
+void xfree(void* pntr) {
     free(pntr);
 }

--- a/src/xmalloc.c
+++ b/src/xmalloc.c
@@ -2,11 +2,21 @@
 
 #include "global.h"
 
-void *xmalloc(size_t bytes) {
 
+/**
+ * behaves the same as malloc but kills the program if malloc fails
+ * @param bytes size of allocation
+ */
+void *xmalloc(size_t bytes) {
     return xmalloc_with_ressources(bytes, NULL, 0);
 }
 
+/**
+ * behaves the same as malloc but kills the program if malloc fails
+ * @param bytes size of allocation
+ * @param pntrs is the list of pointers to free
+ * @param npntrs is the amount of pointers to free = size of array
+ */
 void* xmalloc_with_ressources(size_t bytes, void** ressources, size_t nres) {
     void* temp = malloc(bytes);
     if (temp == NULL) {
@@ -16,11 +26,23 @@ void* xmalloc_with_ressources(size_t bytes, void** ressources, size_t nres) {
     return temp;
 }
 
+/**
+ * behaves the same as calloc but kills the program if malloc fails
+ * @param nelem number of elements
+ * @param bytes byte that is set
+ */
 void* xcalloc(size_t nelem, size_t bytes) {
-
     return xcalloc_with_ressources(nelem, bytes, NULL, 0);
 }
 
+
+/**
+ * behaves the same as calloc but kills the program if malloc fails
+ * @param nelem number of elements
+ * @param bytes byte that is set
+ * @param pntrs is the list of pointers to free
+ * @param npntrs is the amount of pointers to free = size of array
+ */
 void* xcalloc_with_ressources(size_t nelem, size_t bytes, void** ressources, size_t nres) {
     void *temp = calloc(nelem, bytes);
     if (temp == NULL) {
@@ -30,13 +52,24 @@ void* xcalloc_with_ressources(size_t nelem, size_t bytes, void** ressources, siz
     return temp;
 }
 
+/**
+ * behaves the same as xrealloc but kills the program if malloc fails
+ * @param pntr pointer to reallocate
+ * @param bytes new size
+ */
 void* xrealloc(void *pntr, size_t bytes) {
-
     return xrealloc_with_ressources(pntr, bytes, NULL, 0);
 }
 
-void* xrealloc_with_ressources(void* pntr, size_t bytes, void** ressources, size_t nres) {
 
+/**
+ * behaves the same as realloc but kills the program if malloc fails
+ * @param pntr pointer to reallocate
+ * @param bytes new size
+ * @param pntrs is the list of pointers to free
+ * @param npntrs is the amount of pointers to free = size of array
+ */
+void* xrealloc_with_ressources(void* pntr, size_t bytes, void** ressources, size_t nres) {
     void* temp = pntr ? realloc(pntr, bytes) : xmalloc(bytes);
     if (temp == NULL) {
         xfreen(ressources, nres);
@@ -45,12 +78,21 @@ void* xrealloc_with_ressources(void* pntr, size_t bytes, void** ressources, size
     return (temp);
 }
 
+/**
+ * Frees npntrs elements
+ * @param pntrs is the list of pointers to free
+ * @param npntrs is the amount of pointers to free = size of array
+ */
 void xfreen(void** pntrs, size_t npntrs) {
     for (size_t i = 0; i < npntrs; ++i) {
         xfree(pntrs[i]);
     }
 }
 
+/**
+ * behaves the same as free
+ * @param pntr the pointer to be freed
+ */
 void xfree(void* pntr) {
     free(pntr);
 }

--- a/src/xmalloc.c
+++ b/src/xmalloc.c
@@ -4,26 +4,51 @@
 
 void *xmalloc(size_t bytes) {
 
-    void *temp = malloc(bytes);
-    if (temp == NULL)
+    return xmalloc_with_ressources(bytes, NULL, 0);
+}
+
+void *xmalloc_with_ressources(size_t bytes, void** ressources, size_t nres) {
+    void* temp = malloc(bytes);
+    if (temp == NULL) {
+        xfreen(ressources, nres);
         exit_pcalc(MEM_FAIL);
-    return (temp);
+    }
+    return temp;
 }
 
 void *xcalloc(size_t nelem, size_t bytes) {
 
+    return xcalloc_with_ressources(nelem, bytes, NULL, 0);
+}
+
+void *xcalloc_with_ressources(size_t nelem, size_t bytes, void** ressources, size_t nres) {
     void *temp = calloc(nelem, bytes);
-    if (temp == NULL)
+    if (temp == NULL) {
+        xfreen(ressources, nres);
         exit_pcalc(MEM_FAIL);
-    return (temp);
+    }
+    return temp;
 }
 
 void *xrealloc(void *pntr, size_t bytes) {
 
-    void *temp = pntr ? realloc(pntr, bytes) : malloc(bytes);
-    if (temp == NULL)
+    return xrealloc_with_ressources(pntr, bytes, NULL, 0);
+}
+
+void *xrealloc_with_ressources(void *pntr, size_t bytes, void** ressources, size_t nres) {
+
+    void *temp = pntr ? realloc(pntr, bytes) : xmalloc(bytes);
+    if (temp == NULL) {
+        xfreen(ressources, nres);
         exit_pcalc(MEM_FAIL);
+    }
     return (temp);
+}
+
+void xfreen(void** pntrs, size_t npntrs) {
+    for (size_t i = 0; i < npntrs; ++i) {
+        xfree(pntrs[i]);
+    }
 }
 
 void xfree(void *pntr) {


### PR DESCRIPTION
I implemented some functions that clear remaining memory when an allocation fails and thus dont leave allocated memory.

4 new functions:
```
void* xmalloc_with_ressources(size_t bytes, void** ressources, size_t nres);
void* xcalloc_with_ressources(size_t nelem, size_t bytes, void** ressources, size_t nres);
void* xrealloc_with_ressources(void* pntr, size_t bytes, void** ressources, size_t nres);
void xfreen(void** pntrs, size_t npntrs);
```
`void** ressources` are `free`'d when allocation fails
`nres` is the size of ressources


All tests pass and valgrid doesnt show any leakage.

Refactored last long_options array to NULL and not number `0`.