### PR TITLE
Add Makefile code to enhance project build structure

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,7 +1,7 @@
 tests=( "number-bases" "random" "expressions" "input-formats" )
 for t in "${tests[@]}"
 do
-    diff -b tests/$t.correct <(cat tests/$t.test | ./pcalc -n) ||
+    diff -b tests/$t.correct <(cat tests/$t.test | bin/pcalc -n) ||
         if echo "Test failed:"; then
             echo tests/$t
             exit


### PR DESCRIPTION
  * compiled object files will be stored in $(PWD)/build dir
  * executable binary will be stored in $(PWD)/bin dir
  * clean target will simply remove both directories