### PR TITLE
style: parser documentation and better naming

### DIFF
--- a/include/parser.h
+++ b/include/parser.h
@@ -3,7 +3,7 @@
 
 #include "operators.h"
 
-#define MAX_TOKENS 80
+#define MAX_CHARS 80
 
 #define VALID_TOKENS "+-*/%&|$^~<>():;_@0123456789abcdefABCDEFx"
 #define VALID_NUMBER_INPUT "0123456789abcdefx()"
@@ -35,7 +35,7 @@ typedef struct parser_t {
     int pos;
 } * parser_t;
 
-char* tokenize(char*);
+char* sanitize(const char*);
 exprtree parse(char*);
 long long calculate(exprtree);
 void free_exprtree(exprtree);


### PR DESCRIPTION
So throughout parser code 'token' means both the token from lexical analysis and a single character from input string.
This may be confusing.

- renamed some 'token' variables
- added some comments so that parser would be quicker to grasp
- renamed tokenize to sanitize (as it does not tokenizes)

This change does not fix the problem completely.