### PR TITLE
Switch to `uint64_t` instead of `long long` type

### DIFF
--- a/include/global.h
+++ b/include/global.h
@@ -1,6 +1,8 @@
 #ifndef _GLOBAL_H
 #define _GLOBAL_H
 
+#include <stdint.h>
+
 #define MAX_IN 80
 #define INPUT_START 24
 
@@ -8,6 +10,6 @@
 
 void exit_pcalc(int);
 
-char *str_with_base_of_number(long long, int type);
+char *str_with_base_of_number(uint64_t, int type);
 
 #endif

--- a/include/history.h
+++ b/include/history.h
@@ -1,6 +1,7 @@
 #ifndef _HISTORY_H
 #define _HISTORY_H
 
+#include <stdint.h>
 
 #define HISTORY_RECORDS_BEFORE_REALLOC 20
 
@@ -18,7 +19,7 @@ extern struct history history;
 
 void clear_history();
 void add_to_history(struct history* h,char* in);
-void add_number_to_history(long long n, int type);
+void add_number_to_history(uint64_t n, int type);
 void browsehistory(char*, int, int*);
 void free_history(struct history *h);
 

--- a/include/numberstack.h
+++ b/include/numberstack.h
@@ -1,18 +1,20 @@
 #ifndef _NUMBERSTACK_H
 #define _NUMBERSTACK_H
 
+#include <stdint.h>
+
 typedef struct numberstack {
     int max_size;
     int size;
-    long long * elements;
+    uint64_t * elements;
 } numberstack;
 
 extern numberstack* numbers;
 
 numberstack * create_numberstack(int max_size);
-long long * pop_numberstack(numberstack* s);
-long long * top_numberstack(numberstack* s);
-void push_numberstack(numberstack* s, long long value);
+uint64_t * pop_numberstack(numberstack* s);
+uint64_t * top_numberstack(numberstack* s);
+void push_numberstack(numberstack* s, uint64_t value);
 void clear_numberstack(numberstack* s);
 void free_numberstack(numberstack* s);
 

--- a/include/operators.h
+++ b/include/operators.h
@@ -1,6 +1,8 @@
 #ifndef _OPERATORS_H
 #define _OPERATORS_H
 
+#include <stdint.h>
+
 #define DEFAULT_MASK -1
 #define DEFAULT_MASK_SIZE 64
 
@@ -35,17 +37,17 @@
 typedef struct operation {
     char character;
     unsigned char noperands;
-    long long (*execute) (long long, long long);
+    uint64_t (*execute) (uint64_t, uint64_t);
 } operation;
 
-extern unsigned long long globalmask;
+extern uint64_t globalmask;
 extern int globalmasksize;
 extern operation *current_op;
 
 operation* getopcode(char c);
 
-long long shr(long long, long long);
-long long ror(long long, long long);
+uint64_t shr(uint64_t, uint64_t);
+uint64_t ror(uint64_t, uint64_t);
 
 
 #endif

--- a/include/parser.h
+++ b/include/parser.h
@@ -23,7 +23,7 @@ typedef struct exprtree {
     int type;
     union {
         operation* op;
-        long long* value;
+        uint64_t* value;
     };
     struct exprtree* left;
     struct exprtree* right;
@@ -37,7 +37,7 @@ typedef struct parser_t {
 
 char* sanitize(const char*);
 exprtree parse(char*);
-long long calculate(exprtree);
+uint64_t calculate(exprtree);
 void free_exprtree(exprtree);
 
 extern int total_trees_created;

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,4 +1,4 @@
-tests=( "number-bases" "random" "expressions" "input-formats" )
+tests=( "number-bases" "random" "expressions" "input-formats" "corner-cases" )
 for t in "${tests[@]}"
 do
     diff -b tests/$t.correct <(cat tests/$t.test | bin/pcalc -n) ||

--- a/src/draw.c
+++ b/src/draw.c
@@ -24,7 +24,7 @@ int alt_colors_enabled = 0;
 
 int use_interface = 1;
 
-static void printbinary(long long, int);
+static void printbinary(uint64_t, int);
 static void printhistory(numberstack*, int);
 
 void init_gui() {
@@ -73,9 +73,9 @@ void init_gui() {
 
 }
 
-static void printbinary(long long value, int priority) {
+static void printbinary(uint64_t value, int priority) {
 
-    unsigned long long mask = ((long long) 1) << (globalmasksize - 1); // Mask starts at the last bit to display, and is >> until the end
+    uint64_t mask = ((uint64_t) 1) << (globalmasksize - 1); // Mask starts at the last bit to display, and is >> until the end
 
     int i=DEFAULT_MASK_SIZE-globalmasksize;
 
@@ -83,7 +83,7 @@ static void printbinary(long long value, int priority) {
 
     for (; i<64; i++, mask>>=1) {
 
-        unsigned long long bitval = value & mask;
+        uint64_t bitval = value & mask;
         wprintw_colors(displaywin,
             (alt_colors_enabled && bitval) ? COLOR_PAIR_BINARY_ALT : COLOR_PAIR_BINARY,
             "%c", bitval ? '1' : '0');
@@ -108,7 +108,7 @@ static void printhistory(numberstack* numbers, int priority) {
         getyx(displaywin,currY,currX);
         if(currX >= wMaxX-3 || currY > 14) {
             clear_history();
-            long long aux = *top_numberstack(numbers);
+            uint64_t aux = *top_numberstack(numbers);
             add_number_to_history(aux, 0);
         }
         wprintw_colors(displaywin, COLOR_PAIR_HISTORY, "%s ", history.records[i]);
@@ -117,8 +117,8 @@ static void printhistory(numberstack* numbers, int priority) {
 
 void draw(numberstack* numbers, operation* current_op) {
     
-    long long* np = top_numberstack(numbers);
-    long long n;
+    uint64_t* np = top_numberstack(numbers);
+    uint64_t n;
 
     if (np == NULL) n = 0;
     else n = *np;
@@ -136,7 +136,7 @@ void draw(numberstack* numbers, operation* current_op) {
         else mvwprintw_colors(displaywin, 2, 2, COLOR_PAIR_OPERATION, "Operation: %c\n", current_op ? current_op->character : ' ');
 
         if(!decimal_enabled) prio += 2;
-        else mvwprintw_colors(displaywin, 4-prio, 2, COLOR_PAIR_DECIMAL, "Decimal:   %lld", n);
+        else mvwprintw_colors(displaywin, 4-prio, 2, COLOR_PAIR_DECIMAL, "Decimal:   %lld", (long long)n);
 
         if(!hex_enabled) prio += 2;
         else mvwprintw_colors(displaywin, 6-prio, 2, COLOR_PAIR_HEX, "Hex:       0x%llX", n);
@@ -159,7 +159,7 @@ void draw(numberstack* numbers, operation* current_op) {
     }
     else {
 
-        printf("Decimal: %lld, Hex: 0x%llx, Operation: %c\n", n, n, current_op ? current_op->character : ' ');
+        printf("Decimal: %lld, Hex: 0x%llx, Operation: %c\n", (long long)n, (unsigned long long)n, current_op ? current_op->character : ' ');
         /* printf("created|freed -> tokens: %d|%d, parsers: %d|%d, trees: %d|%d\n", total_tokens_created, total_tokens_freed, total_parsers_created, total_parsers_freed, total_trees_created, total_trees_freed); */
     }
 }

--- a/src/history.c
+++ b/src/history.c
@@ -33,7 +33,7 @@ void add_to_history(struct history* h, char* in) {
 
 }
 
-void add_number_to_history(long long n, int type) {
+void add_number_to_history(uint64_t n, int type) {
 
     char *str = str_with_base_of_number(n, type);
     add_to_history(&history, str);
@@ -81,17 +81,17 @@ void free_history(struct history *h) {
 }
 
 
-char *str_with_base_of_number(long long n, int type) {
+char *str_with_base_of_number(uint64_t n, int type) {
 
     char *str = xmalloc(67);
 
     if (type == 0)
-        sprintf(str,"%lld", n);
+        sprintf(str,"%llu", (unsigned long long)n);
     else if (type == 1)
-        sprintf(str,"0x%llX", n);
+        sprintf(str,"0x%llX", (unsigned long long)n);
     else if (type == 2) {
 
-        unsigned long long mask = ror(1, 1);
+        uint64_t mask = ror(1, 1);
 
         int i = 0;
         for (; i<64; i++, mask>>=1)

--- a/src/main.c
+++ b/src/main.c
@@ -136,7 +136,7 @@ int main(int argc, char* argv[])
 
     /*
      * The numberstack is used to store numbers used in calculations
-     * It's a normal stack data structure (LIFO) that holds long long integers
+     * It's a normal stack data structure (LIFO) that holds uint64_t integers
      * Check the stack.h file for its operations
      *
      * The operation structure holds information regarding the ASCII character the operation uses,
@@ -316,7 +316,7 @@ static void process_prompt(operation** current_op, char* prompt) {
 
             // Calculate the result of the expression
             // The globalmask is applied inside calculate
-            long long result = calculate(expression);
+            uint64_t result = calculate(expression);
 
             // The expression is no longer needed since we have its value
             free_exprtree(expression);
@@ -373,12 +373,12 @@ static void apply_operations(numberstack* numbers, operation** current_op) {
 
         if (numbers->size >= noperands) {
 
-            long long operands[2] = {0};
+            uint64_t operands[2] = {0};
 
             for (unsigned char i=0; i < noperands; i++)
                 operands[i] = *pop_numberstack(numbers);
 
-            long long result = (*current_op)->execute(operands[0], operands[1]) & globalmask;
+            uint64_t result = (*current_op)->execute(operands[0], operands[1]) & globalmask;
 
             push_numberstack(numbers, result);
 

--- a/src/numberstack.c
+++ b/src/numberstack.c
@@ -30,7 +30,7 @@ static numberstack * resize_numberstack(numberstack* s) {
 }
 
 // Pop element from the top of the stack (return and remove element)
-long long * pop_numberstack(numberstack* s) {
+uint64_t * pop_numberstack(numberstack* s) {
 
     if (s->size == 0)
         return NULL;
@@ -39,7 +39,7 @@ long long * pop_numberstack(numberstack* s) {
 }
 
 // Return the element at the top of the stack without removing it
-long long * top_numberstack(numberstack* s) {
+uint64_t * top_numberstack(numberstack* s) {
 
     if (s->size == 0)
         return NULL;
@@ -48,7 +48,7 @@ long long * top_numberstack(numberstack* s) {
 }
 
 // Push number to the top of the stack
-void push_numberstack(numberstack* s, long long value) {
+void push_numberstack(numberstack* s, uint64_t value) {
 
     if (s->size == s->max_size)
         resize_numberstack(s);

--- a/src/operators.c
+++ b/src/operators.c
@@ -1,26 +1,27 @@
 #include <stddef.h>
+#include <stdint.h>
 
 #include "operators.h"
 
-unsigned long long globalmask = DEFAULT_MASK;
+uint64_t globalmask = DEFAULT_MASK;
 int globalmasksize = DEFAULT_MASK_SIZE;
 
 operation *current_op = NULL;
 
-static long long add(long long, long long);
-static long long subtract(long long, long long);
-static long long multiply(long long, long long);
-static long long divide(long long, long long);
-static long long and(long long, long long);
-static long long or(long long, long long);
-static long long nor(long long, long long);
-static long long xor(long long, long long);
-static long long shl(long long, long long);
-static long long rol(long long, long long);
-static long long modulus(long long, long long);
-static long long not(long long, long long);
-static long long twos_complement(long long, long long);
-static long long swap_endianness(long long, long long);
+static uint64_t add(uint64_t, uint64_t);
+static uint64_t subtract(uint64_t, uint64_t);
+static uint64_t multiply(uint64_t, uint64_t);
+static uint64_t divide(uint64_t, uint64_t);
+static uint64_t and(uint64_t, uint64_t);
+static uint64_t or(uint64_t, uint64_t);
+static uint64_t nor(uint64_t, uint64_t);
+static uint64_t xor(uint64_t, uint64_t);
+static uint64_t shl(uint64_t, uint64_t);
+static uint64_t rol(uint64_t, uint64_t);
+static uint64_t modulus(uint64_t, uint64_t);
+static uint64_t not(uint64_t, uint64_t);
+static uint64_t twos_complement(uint64_t, uint64_t);
+static uint64_t swap_endianness(uint64_t, uint64_t);
 
 static operation operations[16] = {
     {ADD_SYMBOL, 2, add},
@@ -51,22 +52,22 @@ operation* getopcode(char c)  {
 }
 
 
-static long long add(long long a, long long b) {
+static uint64_t add(uint64_t a, uint64_t b) {
 
     return a + b;
 }
 
 // remember op1 = first popped ( right operand ), op2 = second popped ( left operand )
-static long long subtract(long long a, long long b) {
+static uint64_t subtract(uint64_t a, uint64_t b) {
 
     return b - a;
 }
-static long long multiply(long long a, long long b) {
+static uint64_t multiply(uint64_t a, uint64_t b) {
 
     return a * b;
 }
 
-static long long divide(long long a, long long b) {
+static uint64_t divide(uint64_t a, uint64_t b) {
 
     //TODO not divisible by 0
     if(!a)
@@ -75,51 +76,51 @@ static long long divide(long long a, long long b) {
     return b / a;
 }
 
-static long long and(long long a, long long b) {
+static uint64_t and(uint64_t a, uint64_t b) {
 
     return a & b;
 }
 
-static long long or(long long a, long long b) {
+static uint64_t or(uint64_t a, uint64_t b) {
 
     return a | b;
 }
 
-static long long nor(long long a, long long b) {
+static uint64_t nor(uint64_t a, uint64_t b) {
 
     return ~(a | b);
 }
 
-static long long xor(long long a, long long b) {
+static uint64_t xor(uint64_t a, uint64_t b) {
 
     return a ^ b;
 }
-static long long shl(long long a, long long b) {
+static uint64_t shl(uint64_t a, uint64_t b) {
 
     // Shift longer than type length is undefined behaviour
     return b << a;
 }
 
-long long shr(long long a, long long b) {
+uint64_t shr(uint64_t a, uint64_t b) {
 
     // Shift longer than 64 bits is undefined behaviour
     // don't include shift in tests or //TODO: define behaviour for this calculator
-    return ((unsigned long long) b >> a);
+    return ((uint64_t) b >> a);
 }
 
-static long long rol(long long a, long long b) {
+static uint64_t rol(uint64_t a, uint64_t b) {
 
     // prevent shift by 64 bits because a shift longer than type length is undefined behaviour
     return b << a | ( globalmasksize - a < 64 ? shr(globalmasksize - a, b) : 0 );
 }
 
-long long ror(long long a, long long b) {
+uint64_t ror(uint64_t a, uint64_t b) {
 
     // prevent shift by 64 bits because a shift longer than type length is undefined behaviour
     return shr(a, b) | (globalmasksize - a < 64 ? b << (globalmasksize - a) : 0);
 }
 
-static long long modulus(long long a, long long b) {
+static uint64_t modulus(uint64_t a, uint64_t b) {
 
     //TODO not divisible by 0
     if(!a)
@@ -128,19 +129,19 @@ static long long modulus(long long a, long long b) {
     return b % a;
 }
 
-static long long not(long long a, long long UNUSED(b)) {
+static uint64_t not(uint64_t a, uint64_t UNUSED(b)) {
 
     return ~a;
 }
 
-static long long twos_complement(long long a, long long UNUSED(b)) {
+static uint64_t twos_complement(uint64_t a, uint64_t UNUSED(b)) {
 
     return -a;
 }
 
-static long long swap_endianness(long long a, long long UNUSED(b)) {
+static uint64_t swap_endianness(uint64_t a, uint64_t UNUSED(b)) {
 
-    long long out = 0;
+    uint64_t out = 0;
     // shift the leftmost bits to the right
     for (int i = 0; i < globalmasksize / 16; i++) {
         //        create a bitmask and apply it to a        and shift the selected byte to its new position

--- a/src/parser.c
+++ b/src/parser.c
@@ -1,4 +1,5 @@
 #include <assert.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -90,7 +91,7 @@ exprtree parse(char* input) {
 /**
  * @brief Calculate a numeric value from an expression tree
  */
-long long calculate(exprtree expr) {
+uint64_t calculate(exprtree expr) {
 
     // expr shouldn't be null if being calculated.
     assert(expr != NULL);
@@ -98,12 +99,12 @@ long long calculate(exprtree expr) {
 
     if (expr->type == OP_TYPE) {
 
-        long long left_value = calculate(expr->left);
+        uint64_t left_value = calculate(expr->left);
 
-        long long right_value = calculate(expr->right);
+        uint64_t right_value = calculate(expr->right);
 
         // Execute takes the operands switched because the stack inverts the order of the numbers
-        long long value = expr->op->execute(right_value, left_value);
+        uint64_t value = expr->op->execute(right_value, left_value);
 
         return value & globalmask;
 
@@ -222,7 +223,7 @@ static exprtree parse_prefix_expr(parser_t parser) {
     // TODO: Display input invalid instead of using a zero-val expression
     if (!(parser->pos < parser->ntokens)) {
 
-        long long zerov = 0;
+        uint64_t zerov = 0;
         return create_exprtree(DEC_TYPE, &zerov, NULL, NULL);
     }
 
@@ -265,7 +266,7 @@ static exprtree parse_prefix_expr(parser_t parser) {
         // Two's complement serves the same logic - since it only uses one parameter we can set the other as anything
 
         // So we create an expression with 0 on the left, and the correct op, and it works
-        long long zero_val = 0;
+        uint64_t zero_val = 0;
         exprtree zero_val_expr = create_exprtree(DEC_TYPE, &zero_val, NULL, NULL);
         return create_exprtree(OP_TYPE, op, zero_val_expr, expr);
     }
@@ -284,7 +285,7 @@ static exprtree parse_atom_expr(parser_t parser) {
     // to be parsed. There are possibly more cases
     if (!(parser->pos < parser->ntokens)) {
 
-        long long zerov = 0;
+        uint64_t zerov = 0;
         return create_exprtree(DEC_TYPE, &zerov, NULL, NULL);
     }
 
@@ -310,7 +311,7 @@ static exprtree parse_atom_expr(parser_t parser) {
         else {
 
             // For now, everything to the right of an unclosed left parenthesis will be equivalent to 0
-            long long zerov = 0;
+            uint64_t zerov = 0;
             return create_exprtree(DEC_TYPE, &zerov, NULL, NULL);
 
             // TODO: Find a way to do error handling and displaying, possibly give one more type to exprtree type = ERR_TYPE and have in the union a char* for the error message
@@ -390,7 +391,7 @@ static exprtree parse_number(parser_t parser) {
     // and possibly in other situations
     if (numberlen == 0) {
 
-        long long zerov = 0;
+        uint64_t zerov = 0;
         return create_exprtree(DEC_TYPE, &zerov, NULL, NULL);
     }
 
@@ -408,7 +409,7 @@ static exprtree parse_number(parser_t parser) {
             break;
     }
 
-    long long value = strtoll(numberfound, NULL, numberbase);
+    uint64_t value = strtoull(numberfound, NULL, numberbase);
 
     exprtree number_expr = create_exprtree(numbertype, &value, NULL, NULL);
 
@@ -429,7 +430,7 @@ static exprtree parse_stdop_expr(parser_t parser, char* ops, exprtree (*parse_in
     // This is a temporary fix that returns the expression immediately as zero.
     if (!(parser->pos < parser->ntokens)) {
 
-        long long zerov = 0;
+        uint64_t zerov = 0;
         return create_exprtree(DEC_TYPE, &zerov, NULL, NULL);
     }
 
@@ -470,7 +471,7 @@ static exprtree create_exprtree(int type, void* content, exprtree left, exprtree
 
         void* allocated[] = { expr };
         expr->value = xmalloc_with_ressources(sizeof(*expr->value), allocated, 1);
-        *(expr->value) = *((long long*) content);
+        *(expr->value) = *((uint64_t*) content);
     }
 
     expr->left = left;

--- a/tests/corner-cases.correct
+++ b/tests/corner-cases.correct
@@ -1,0 +1,5 @@
+Decimal: 0, Hex: 0x0, Operation:  
+Decimal: 9223372036854775807, Hex: 0x7fffffffffffffff, Operation:  
+Decimal: -9223372036854775808, Hex: 0x8000000000000000, Operation:  
+Decimal: -1, Hex: 0xffffffffffffffff, Operation:  
+Decimal: -2, Hex: 0xfffffffffffffffe, Operation:  

--- a/tests/corner-cases.test
+++ b/tests/corner-cases.test
@@ -1,0 +1,5 @@
+0x7fffffffffffffff
+0x8000000000000000
+0xffffffffffffffff
+0xfffffffffffffffe
+exit

--- a/tests/how-to-test.md
+++ b/tests/how-to-test.md
@@ -2,11 +2,11 @@
 
 The folder `tests` has two files for each test. `file.test` and `file.correct`
 
-The `.test` file is the input passed into `pcalc -c`, and the `.correct` file is the expected output
+The `.test` file is the input passed into `pcalc -n`, and the `.correct` file is the expected output
 
 To test one of these files run:
 ```
-$ diff -b tests/number-bases.correct <(cat tests/number-bases.test | ./pcalc -c)
+$ diff -b tests/number-bases.correct <(cat tests/number-bases.test | ./pcalc -n)
 ```
 
 If something is printed out to the console then the actual output and the expected output differ, and changes should be made until all tests pass.
@@ -30,10 +30,10 @@ I've found that the best way to write a test is by testing multiple operations i
 
 First: Test input while saving it
 ```
-$ tee -a tests/name-of-test.test | ./pcalc -c
+$ tee -a tests/name-of-test.test | ./pcalc -n
 ```
 
 If all results from the input inserted are correct, save the output as the correction
 ```
-$ cat tests/name-of-test.test | ./pcalc -c > name-of-test.correct
+$ cat tests/name-of-test.test | ./pcalc -n > name-of-test.correct
 ```


### PR DESCRIPTION
Use of `strtoll()` makes it impossible to enter values in the range `[LONG_LONG_MAX + 1; ULONG_LONG_MAX]`.

Also use of signed integers in operations that overflow invokes undefined behaviour per C standard.

The interface even assumes 64 bits in the type, so I've used `uint64_t` instead of `unsigned long long` which can have different width.

`%lld` and other printf-like formats accept `long long` or `unsigned long long` and `uint64_t` is likely to be `unsigned long` or some other type which is different from `unsigned long long` even if its width matches, hence casts in several places.

Operations with negative numbers still work and tests pass, but some cases might need correction in the future due to this sign change.

***

Also fix command-line flag mentioned in `how-to-test.md`, it's `-n`, not `-c`.