### PR TITLE
Fixed compiling error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # https://github.com/danielpinto8zz6/c-cpp-project-generator#readme
 
 CC = gcc
-CFLAGS := -Wall -Wextra -g -Werror=missing-declarations -Werror=redundant-decls
+CFLAGS := -std=c11 -Wall -Wextra -g -Werror=missing-declarations -Werror=redundant-decls -D_DEFAULT_SOURCE -pedantic-errors
 LFLAGS = -lncurses
 # OUTPUT := output
 SRC := src

--- a/src/main.c
+++ b/src/main.c
@@ -30,7 +30,7 @@
 static void process_prompt(operation**, char*);
 static void get_input(char*);
 static void apply_operations(numberstack*, operation**);
-static void exit_pcalc_success();
+static void exit_pcalc_success(int);
 
 
 
@@ -135,7 +135,7 @@ int main(int argc, char* argv[])
     }
 
 
-    init_gui(&displaywin, &inputwin);
+    init_gui();
 
     // Set handler for CTRL+C to clean exit
     signal(SIGINT, exit_pcalc_success);
@@ -633,7 +633,7 @@ void exit_pcalc(int code) {
     exit(code);
 }
 
-static void exit_pcalc_success() {
+static void exit_pcalc_success(int d __attribute__((unused))) {
 
     exit_pcalc(0);
 }


### PR DESCRIPTION
The issues described in #103 are fixed.
They were undetected beacuse gcc used an older compiler version which did not raise an error.
I changed the code to be compliant with c23 and set this in the Makefile thus future changes in the default compiler version continue to compile.

The pull request #100 should also be considered to be merged as it may result in compiler errors because some systems separate ncurses and tinfo more strictly and thus result in an error.